### PR TITLE
Implement `GetScroll` API Method

### DIFF
--- a/CustomBackpackApi.cs
+++ b/CustomBackpackApi.cs
@@ -6,8 +6,9 @@ namespace CustomBackpack
     {
         public bool SetPlayerSlots(int slots, bool force);
         public bool ChangeScroll(InventoryMenu menu, int delta);
+        public int GetScroll();
     }
-    public class CustomBackpackApi
+    public class CustomBackpackApi : ICustomBackpackApi
     {
         public bool SetPlayerSlots(int slots, bool force)
         {
@@ -16,6 +17,10 @@ namespace CustomBackpack
         public bool ChangeScroll(InventoryMenu menu, int delta)
         {
             return ModEntry.ChangeScroll(menu, delta);
+        }
+        public int GetScroll()
+        {
+            return ModEntry.GetScroll();
         }
     }
 }

--- a/Methods.cs
+++ b/Methods.cs
@@ -179,6 +179,10 @@ namespace CustomBackpack
             return false;
         }
 
+        public static int GetScroll()
+        {
+            return scrolled.Value;
+        }
 
         public static void DrawUIElements(SpriteBatch b, InventoryMenu __instance)
         {


### PR DESCRIPTION
I've gotten requests to implement support for Custom Backpack Framework in my Convenient Inventory mod. I took a look at your public API and realized I could implement support very easily if there was a way to obtain the value of `ModEntry.scrolled`. Without this, I cannot determine which slots are currently being drawn on the screen for Custom Backpack Framework's scrollable inventory, since the current row the player has scrolled to is not exposed via API.

This PR implement a new `GetScroll` method in the `CustomBackpackApi` class and exposes it via the `ICustomBackpackApi` interface.

The alternative way to accomplish this is by simply accessing this field myself via Reflection into your assembly, but that is not future-proof and relies on your code.

Let me know what you think and if these changes look good.