### PR TITLE
Avoid using checkHeldItem() to improve android compatibility

### DIFF
--- a/FullInventoryPage.cs
+++ b/FullInventoryPage.cs
@@ -54,11 +54,11 @@ namespace CustomBackpack
             trashCan.bounds.Y = organizeButton.bounds.Y + 256;
             trashCan.draw(b);
             b.Draw(Game1.mouseCursors, new Vector2(trashCan.bounds.X + 60, trashCan.bounds.Y + 40), new Rectangle?(new Rectangle(564 + Game1.player.trashCanLevel * 18, 129, 18, 10)), Color.White, trashCanLidRotation, new Vector2(16f, 10f), 4f, SpriteEffects.None, 0.86f);
-            if (checkHeldItem(null))
+            if (Game1.player.CursorSlotItem != null)
             {
                 Game1.player.CursorSlotItem.drawInMenu(b, new Vector2(Game1.getOldMouseX() + 16, Game1.getOldMouseY() + 16), 1f);
             }
-            if (hoverText != null && !hoverText.Equals(""))
+            if (!string.IsNullOrEmpty(hoverText))
             {
                 if (hoverAmount > 0)
                 {
@@ -66,7 +66,7 @@ namespace CustomBackpack
                 }
                 else
                 {
-                    drawToolTip(b, hoverText, hoverTitle, hoveredItem, checkHeldItem(null), -1, 0, null, -1, null, -1);
+                    drawToolTip(b, hoverText, hoverTitle, hoveredItem, Game1.player.CursorSlotItem != null, -1, 0, null, -1, null, -1);
                 }
             }
             drawMouse(b);


### PR DESCRIPTION
The Android version of the game apparently does not have the
checkHeldItem() function in its InventoryPage. This function checks if
CursorSlotItem is null, but optionally takes a function to test the
currently held item with.

We never use the function, and just use it to check whether there is any
held item. Instead of using the function, replace the code to simply
directly check of Game1.player.CustorSlotItem is not null. This removes
one incompatibility with the Android version of the game.

While at it, convert the hoverText checks to use IsNullOrEmpty as
pointed out by YourJeiJi.

Signed-off-by: Jacob Keller <jacob.keller@gmail.com>
