### PR TITLE
Fix toolbar shifting when inventory has items

### DIFF
--- a/CodePatches.cs
+++ b/CodePatches.cs
@@ -455,7 +455,16 @@ namespace CustomBackpack
 
             public static bool Farmer_shiftToolbar_Prefix(Farmer __instance, bool right)
             {
-                if (!Config.ModEnabled || Config.ShiftRows < 1 || Config.ShiftRows >= __instance.Items.Count / 12 || __instance.Items is null || __instance.Items.Count < 37 || __instance.UsingTool || Game1.dialogueUp || !__instance.CanMove || __instance.Items.HasAny() || Game1.eventUp || Game1.farmEvent != null)
+                if (!Config.ModEnabled
+                    || __instance.Items is null
+                    || Config.ShiftRows < 1
+                    || Config.ShiftRows >= __instance.Items.Count / 12
+                    || __instance.Items.Count < 37
+                    || __instance.UsingTool
+                    || Game1.dialogueUp
+                    || !__instance.CanMove
+                    || Game1.eventUp
+                    || Game1.farmEvent != null)
                     return true;
                 if (Config.ShiftRows == 1)
                     return false;


### PR DESCRIPTION
The Farmer_shiftToolbar_Prefix function intercepts the toolbar shifting
logic to allow configuring how many rows are shifted. This function
checks many conditions to decide when to execute, including whether the
inventory has items in it.

Checking the number of actual items is incorrect, as it prevents
shifting the toolbar when there are any items. We could invert the check
to only execute if there is at least one item. Instead, just remove this
check and shift regardless of whether there are items in the inventory.

Fixes #5

Signed-off-by: Jacob Keller <jacob.keller@gmail.com>
