### PR TITLE
Expose ShiftRows in the API

### DIFF
--- a/CustomBackpackApi.cs
+++ b/CustomBackpackApi.cs
@@ -7,6 +7,7 @@ namespace CustomBackpack
         public bool SetPlayerSlots(int slots, bool force);
         public bool ChangeScroll(InventoryMenu menu, int delta);
         public int GetScroll();
+        public int GetShiftRows();
     }
     public class CustomBackpackApi : ICustomBackpackApi
     {
@@ -21,6 +22,10 @@ namespace CustomBackpack
         public int GetScroll()
         {
             return ModEntry.GetScroll();
+        }
+        public int GetShiftRows()
+        {
+            return ModEntry.GetShiftRows();
         }
     }
 }

--- a/Methods.cs
+++ b/Methods.cs
@@ -184,6 +184,11 @@ namespace CustomBackpack
             return scrolled.Value;
         }
 
+        public static int GetShiftRows()
+        {
+            return Config?.ShiftRows ?? new ModConfig().ShiftRows;
+        }
+
         public static void DrawUIElements(SpriteBatch b, InventoryMenu __instance)
         {
             int mouseX = Game1.getMouseX();


### PR DESCRIPTION
Add access to read the current ShiftRows value as part of the API of the
CustomBackpackFramework API. This enables other mods to behave correctly
dependent on the current shift behavior, for example to better
interoperate between CBF and Toolbar-Switch.

Fixes #6

Signed-off-by: Jacob Keller <jacob.keller@gmail.com>
