### PR TITLE
Make SeedShop.draw prefix conditional

### DIFF
--- a/ModEntry.cs
+++ b/ModEntry.cs
@@ -128,10 +128,15 @@ namespace CustomBackpack
                 postfix: new HarmonyMethod(typeof(ObjectPatches), nameof(ObjectPatches.InventoryMenu_draw_Postfix))
             );
 
-            harmony.Patch(
-                original: AccessTools.Method(typeof(SeedShop), nameof(SeedShop.draw)),
-                prefix: new HarmonyMethod(typeof(ObjectPatches), nameof(ObjectPatches.SeedShop_draw_Prefix))
-            );
+            var seedShopDraw = AccessTools.Method(typeof(SeedShop), nameof(SeedShop.draw));
+            if (seedShopDraw != null) {
+                harmony.Patch(
+                    original: seedShopDraw,
+                    prefix: new HarmonyMethod(typeof(ObjectPatches), nameof(ObjectPatches.SeedShop_draw_Prefix))
+                );
+            } else {
+                SMonitor.Log("SeedShop.draw method not found on this platform. SeedShop draw patch will not be applied.", LogLevel.Warn);
+            }
 
             harmony.Patch(
                 original: AccessTools.Method(typeof(GameLocation), nameof(GameLocation.performAction), new Type[] { typeof(string[]), typeof(Farmer), typeof(Location) }),


### PR DESCRIPTION
Apparently the Android platform does not have SeedShop.draw, so the
harmony patch to prefix this function does not work. Fix this by making
the patch conditional on the method. This is unlikely to be a complete
fix for android compatibility as we are removing a possibly necessary
patch with no alternative. However, this should be a step towards
compatibility.

Signed-off-by: Jacob Keller <jacob.keller@gmail.com>
